### PR TITLE
Setting _cameraDevice on _setupCaptureSession and also start and stop running the session on a background thread to increase loading performance

### DIFF
--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -242,12 +242,16 @@ CGFloat const kFocusSquareSize = 50.f;
 
 - (void)_startRunning
 {
-    [_session startRunning];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [_session startRunning];
+    });
 }
 
 - (void)_stopRunning
 {
-    [_session stopRunning];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [_session stopRunning];
+    });
 }
 
 - (void)_insertPreviewLayerInView:(UIView *)rootView
@@ -282,6 +286,19 @@ CGFloat const kFocusSquareSize = 50.f;
 #if !TARGET_IPHONE_SIMULATOR
     AVCaptureDeviceInput *deviceInput = [AVCaptureDeviceInput deviceInputWithDevice:device error:nil];
     [_session addInput:deviceInput];
+    
+    switch (device.position) {
+        case AVCaptureDevicePositionBack:
+            _cameraDevice = FastttCameraDeviceRear;
+            break;
+            
+        case AVCaptureDevicePositionFront:
+            _cameraDevice = FastttCameraDeviceFront;
+            break;
+            
+        default:
+            break;
+    }
 #endif
     
     NSDictionary *outputSettings = @{AVVideoCodecKey:AVVideoCodecJPEG};


### PR DESCRIPTION
This sets the _cameraDevice property to something (based on the defaultDevice for Video) on _setupCaptureSession. Need to do that because on swift, when the FastttCamera loads, i check for the cameraDevice property and it is not equal to rear (the default).

Also this start and stop running the capture session on a background thread to avoid locking the UI: https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVCaptureSession_Class/index.html#//apple_ref/occ/instm/AVCaptureSession/startRunning
