### PR TITLE
Handle Camera Permissions Denied

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - Expecta+Snapshots (1.3.1):
     - Expecta
     - FBSnapshotTestCase
-  - FastttCamera (0.2.1):
-    - FastttCamera/Default (= 0.2.1)
-  - FastttCamera/Default (0.2.1)
+  - FastttCamera (0.2.2):
+    - FastttCamera/Default (= 0.2.2)
+  - FastttCamera/Default (0.2.2)
   - FBSnapshotTestCase (1.5)
   - Masonry (0.6.1)
   - OCMock (3.1.2)
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Expecta: ee641011fe10aa1855d487b40e4976dac50ec342
   Expecta+Snapshots: 4a56b9411c6ed156987072e52c39de67d864015a
-  FastttCamera: 9485f1435db8621044b4951dcebac9bdd0db7e00
+  FastttCamera: 85ba678cf0602c97544798d3f7758bda9159d5a9
   FBSnapshotTestCase: e2914fbaabccea1dcc773d6a16b1c24540642488
   Masonry: 2cb49fd14d203d2db5ca6bb017135b235dde9980
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.2.1"
+  s.version          = "0.2.2"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -237,4 +237,17 @@
  */
 - (void)cameraController:(id<FastttCameraInterface>)cameraController didFinishNormalizingCapturedImage:(FastttCapturedImage *)capturedImage;
 
+/**
+ *  Called when the camera controller asks for permission to access the user's camera and is denied.
+ *
+ *  @param cameraController The FastttCamera instance.
+ *
+ *  @note Use this optional method to handle gracefully the case where the user has denied camera access, either disabling the camera
+ *  if not necessary or redirecting the user to your app's Settings page where they can enable the camera permissions. Remember that iOS
+ *  will only show the user an alert requesting permission in-app one time. If the user denies permission, they must change this setting
+ *  in the app's permissions page within the Settings App. This method will be called every time the app launches or becomes active and
+ *  finds that permission to access the camera has not been granted.
+ */
+- (void)userDeniedCameraPermissionsForCameraController:(id<FastttCameraInterface>)cameraController;
+
 @end

--- a/FiltersExample/Podfile.lock
+++ b/FiltersExample/Podfile.lock
@@ -3,8 +3,8 @@ PODS:
   - Expecta+Snapshots (1.3.1):
     - Expecta
     - FBSnapshotTestCase
-  - FastttCamera/Default (0.2.1)
-  - FastttCamera/Filters (0.2.1):
+  - FastttCamera/Default (0.2.2)
+  - FastttCamera/Filters (0.2.2):
     - FastttCamera/Default
     - GPUImage (~> 0.1.0)
   - FBSnapshotTestCase (1.5)
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Expecta: ee641011fe10aa1855d487b40e4976dac50ec342
   Expecta+Snapshots: 4a56b9411c6ed156987072e52c39de67d864015a
-  FastttCamera: 9485f1435db8621044b4951dcebac9bdd0db7e00
+  FastttCamera: 85ba678cf0602c97544798d3f7758bda9159d5a9
   FBSnapshotTestCase: e2914fbaabccea1dcc773d6a16b1c24540642488
   GPUImage: cecb0830bb9428f50192042e3c7b53810f51388e
   Masonry: 2cb49fd14d203d2db5ca6bb017135b235dde9980


### PR DESCRIPTION
Handle camera permission denial more gracefully, with a new delegate method to allow apps to update the UI to reflect lack of access, or to prompt the user to grant permission in the Settings app.
