### PR TITLE
Add delegate callback for raw jpeg data

### DIFF
--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -497,7 +497,11 @@
          }
          
          NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageDataSampleBuffer];
-         
+
+         if ([self.delegate respondsToSelector:@selector(cameraController:didFinishCapturingImageData:)]) {
+             [self.delegate cameraController:self didFinishCapturingImageData:imageData];
+         }
+
          dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
              
              UIImage *image = [UIImage imageWithData:imageData];

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -220,6 +220,16 @@
 @optional
 
 /**
+ *  Called when the camera controller has obtained the raw data containing the image and metadata.
+ *
+ *  @param cameraController The FastttCamera instance that captured a photo.
+ *
+ *  @param rawJPEGData The plain, raw data from the camera, ready to be written to a file if desired.
+ *
+*/
+- (void)cameraController:(id<FastttCameraInterface>)cameraController didFinishCapturingImageData:(NSData *)rawJPEGData;
+
+/**
  *  Called when the camera controller has finished capturing a photo.
  *
  *  @param cameraController The FastttCamera instance that captured a photo.


### PR DESCRIPTION
This is useful for taking the jpeg with the included metadata (EXIF, etc) and
saving it to disk or accessing EXIF. This metadata is lost when the image is
converted to a UIImage.

I'm happy to add tests for this if there is a good suggestion on how best to do that.
