### PR TITLE
fix focus/exposure issue

### DIFF
--- a/FastttCamera/AVCaptureDevice+FastttCamera.m
+++ b/FastttCamera/AVCaptureDevice+FastttCamera.m
@@ -111,20 +111,20 @@
 {
     if ([self lockForConfiguration:nil]) {
         
-        if ([self isFocusModeSupported:AVCaptureFocusModeContinuousAutoFocus]) {
-            self.focusMode = AVCaptureFocusModeContinuousAutoFocus;
-        }
-        
-        if ([self isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]) {
-            self.exposureMode = AVCaptureExposureModeContinuousAutoExposure;
-        }
-        
         if (self.focusPointOfInterestSupported) {
             self.focusPointOfInterest = pointOfInterest;
         }
         
         if (self.exposurePointOfInterestSupported) {
             self.exposurePointOfInterest = pointOfInterest;
+        }
+        
+        if ([self isFocusModeSupported:AVCaptureFocusModeContinuousAutoFocus]) {
+            self.focusMode = AVCaptureFocusModeContinuousAutoFocus;
+        }
+        
+        if ([self isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]) {
+            self.exposureMode = AVCaptureExposureModeContinuousAutoExposure;
         }
         
         [self unlockForConfiguration];


### PR DESCRIPTION
when tap to set the point of focus or exposure, the highlight yellow rect is correct, but actual focus point is at previous position.
