### PR TITLE
Remove exclusive => true

### DIFF
--- a/FiltersExample/Podfile
+++ b/FiltersExample/Podfile
@@ -9,11 +9,11 @@ def install_pods
   pod 'Masonry', '0.6.1'
 end
 
-target 'FastttCameraDemo', :exclusive => true do
+target 'FastttCameraDemo' do
   install_pods
 end
 
-target 'FastttCameraDemoTests', :exclusive => true do
+target 'FastttCameraDemoTests' do
   install_pods
   pod 'Specta'
   pod 'Expecta'


### PR DESCRIPTION
Running `pod install` for the FilterExample fails and generates an error. The `exclusive` option was removed from Cocoapods as noted [here](https://github.com/CocoaPods/CocoaPods/issues/4705). The install works when this is removed. 
