### PR TITLE
Don't assume portrait orientation if UIDeviceOrientation is FaceUp/FaceDown

### DIFF
--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.4"
+  s.version          = "0.3.5"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.5"
+  s.version          = "0.3.6"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.6"
+  s.version          = "0.3.7"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.7"
+  s.version          = "0.3.8"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.12"
+  s.version          = "0.3.13"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.8"
+  s.version          = "0.3.9"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.9"
+  s.version          = "0.3.10"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.16"
+  s.version          = "0.3.17"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.13"
+  s.version          = "0.3.14"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.19"
+  s.version          = "0.3.20"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.18"
+  s.version          = "0.3.19"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.17"
+  s.version          = "0.3.18"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.14"
+  s.version          = "0.3.15"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.11"
+  s.version          = "0.3.12"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.10"
+  s.version          = "0.3.11"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera.podspec
+++ b/FastttCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FastttCamera"
-  s.version          = "0.3.15"
+  s.version          = "0.3.16"
   s.summary          = "A fast, straightforward implementation of AVFoundation camera with customizable real-time photo filters."
   s.homepage         = "https://github.com/IFTTT/FastttCamera"
   s.license          = 'MIT'

--- a/FastttCamera/FastttCamera.h
+++ b/FastttCamera/FastttCamera.h
@@ -9,10 +9,6 @@
 #import <UIKit/UIKit.h>
 #import "FastttCameraInterface.h"
 
-FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationName;
-FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationErrorKey;
-FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationStateKey;
-
 /**
  *  Public class for you to use to create a standard FastttCamera!
  *

--- a/FastttCamera/FastttCamera.h
+++ b/FastttCamera/FastttCamera.h
@@ -20,7 +20,7 @@
  */
 @interface FastttCamera : UIViewController <FastttCameraInterface, AVCaptureVideoDataOutputSampleBufferDelegate>
 
-// use this if you want the delegate to receive video frames
-- (instancetype)initWithSendIndividualVideoFrames:(BOOL)sendIndividualVideoFrames;
+// if you want the delegate to receive video frames
+@property (nonatomic, assign) BOOL sendIndividualVideoFrames;
 
 @end

--- a/FastttCamera/FastttCamera.h
+++ b/FastttCamera/FastttCamera.h
@@ -9,6 +9,10 @@
 #import <UIKit/UIKit.h>
 #import "FastttCameraInterface.h"
 
+FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationName;
+FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationErrorKey;
+FOUNDATION_EXPORT NSString* const FastttCameraStateNotificationStateKey;
+
 /**
  *  Public class for you to use to create a standard FastttCamera!
  *

--- a/FastttCamera/FastttCamera.h
+++ b/FastttCamera/FastttCamera.h
@@ -18,6 +18,9 @@
  *  @note If you want to use filters with your live camera preview,
  *  use an instance of FastttFilterCamera instead.
  */
-@interface FastttCamera : UIViewController <FastttCameraInterface>
+@interface FastttCamera : UIViewController <FastttCameraInterface, AVCaptureVideoDataOutputSampleBufferDelegate>
+
+// use this if you want the delegate to receive video frames
+- (instancetype)initWithSendIndividualVideoFrames:(BOOL)sendIndividualVideoFrames;
 
 @end

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -530,6 +530,10 @@
 #else    
     UIDeviceOrientation previewOrientation = [self _currentPreviewDeviceOrientation];
 
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+        NSLog(@"FastttCamera: must be showing video to take photo");
+        return;
+    }
     [_stillImageOutput captureStillImageAsynchronouslyFromConnection:videoConnection
                                                    completionHandler:^(CMSampleBufferRef imageDataSampleBuffer, NSError *error)
      {

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -453,6 +453,7 @@
                 
                 _stillImageOutput = [AVCaptureStillImageOutput new];
                 _stillImageOutput.outputSettings = outputSettings;
+                _stillImageOutput.highResolutionStillImageOutputEnabled = YES;
                 
                 [_session addOutput:_stillImageOutput];
                 
@@ -507,6 +508,8 @@
     BOOL needsPreviewRotation = ![self.deviceOrientation deviceOrientationMatchesInterfaceOrientation];
     
     AVCaptureConnection *videoConnection = [self _currentCaptureConnection];
+    if (!videoConnection.isActive)
+        return;
     
     if ([videoConnection isVideoOrientationSupported]) {
         [videoConnection setVideoOrientation:[self _currentCaptureVideoOrientationForDevice]];

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -16,10 +16,6 @@
 #import "FastttZoom.h"
 #import "FastttCapturedImage+Process.h"
 
-NSString* const FastttCameraStateNotificationName = @"stateNotification";
-NSString* const FastttCameraStateNotificationErrorKey = @"errorKey";
-NSString* const FastttCameraStateNotificationStateKey = @"stateKey";
-
 @interface FastttCamera () <FastttFocusDelegate, FastttZoomDelegate>
 
 @property (nonatomic, strong) IFTTTDeviceOrientation *deviceOrientation;
@@ -117,37 +113,6 @@ NSString* const FastttCameraStateNotificationStateKey = @"stateKey";
     [self _teardownCaptureSession];
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (void)sessionRuntimeError:(NSNotification *)notification {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    dict[FastttCameraStateNotificationStateKey] = @"sessionRuntimeError";
-    NSError *error = notification.userInfo[AVCaptureSessionErrorKey];
-    if (error)
-        dict[FastttCameraStateNotificationErrorKey] = error;
-    [[NSNotificationCenter defaultCenter] postNotificationName:FastttCameraStateNotificationName object:nil userInfo:dict];
-    
-    [self _teardownCaptureSession];
-}
-
-- (void)sessionWasInterrupted:(NSNotification *)notification {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    dict[FastttCameraStateNotificationStateKey] = @"sessionWasInterrupted";
-    id reason = notification.userInfo[AVCaptureSessionInterruptionReasonKey];
-    if (reason)
-        dict[FastttCameraStateNotificationErrorKey] = reason;
-    [[NSNotificationCenter defaultCenter] postNotificationName:FastttCameraStateNotificationName object:nil userInfo:dict];
-
-    [self _teardownCaptureSession];
-}
-
-- (void)sessionInterruptionEnded:(NSNotification *)notification {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    dict[FastttCameraStateNotificationStateKey] = @"sessionInterruptionEnded";
-    [[NSNotificationCenter defaultCenter] postNotificationName:FastttCameraStateNotificationName object:nil userInfo:dict];
-
-    [self _teardownCaptureSession];
-    [self _setupCaptureSession];
 }
 
 #pragma mark - View Events
@@ -461,10 +426,6 @@ NSString* const FastttCameraStateNotificationStateKey = @"stateKey";
                 
                 _session = [AVCaptureSession new];
                 _session.sessionPreset = AVCaptureSessionPresetPhoto;
-
-                [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionRuntimeError:) name:AVCaptureSessionRuntimeErrorNotification object:self.session];
-                [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionWasInterrupted:) name:AVCaptureSessionWasInterruptedNotification object:self.session];
-                [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionInterruptionEnded:) name:AVCaptureSessionInterruptionEndedNotification object:self.session];
 
                 AVCaptureDevice *device = [AVCaptureDevice cameraDevice:self.cameraDevice];
                 

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -687,11 +687,34 @@
         case UIDeviceOrientationLandscapeRight:
             return AVCaptureVideoOrientationLandscapeLeft;
             
+        case UIDeviceOrientationFaceUp:
+        case UIDeviceOrientationFaceDown:
+            return [self.class _videoOrientationFromStatusBarOrientation];
+            
         default:
             break;
     }
     
     return AVCaptureVideoOrientationPortrait;
+}
+
++ (AVCaptureVideoOrientation)_videoOrientationFromStatusBarOrientation {
+    switch ([UIApplication sharedApplication].statusBarOrientation) {
+        case UIInterfaceOrientationLandscapeLeft:
+            return AVCaptureVideoOrientationLandscapeLeft;
+
+        case UIInterfaceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeRight;
+            
+        case UIInterfaceOrientationPortrait:
+            return AVCaptureVideoOrientationPortrait;
+
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return AVCaptureVideoOrientationPortraitUpsideDown;
+            
+        default:
+            return AVCaptureVideoOrientationPortrait;
+    }
 }
 
 #pragma mark - Camera Permissions

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -393,6 +393,10 @@
 
 - (void)_insertPreviewLayer
 {
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+
     if (!_deviceAuthorized || !_session) {
         return;
     }
@@ -430,6 +434,8 @@
     NSAssert([NSThread currentThread].isMainThread, @"ERROR must be main thread here");
 
     _session = [AVCaptureSession new];
+
+#if !TARGET_IPHONE_SIMULATOR
     _session.sessionPreset = AVCaptureSessionPresetPhoto;
     
     AVCaptureDevice *device = [AVCaptureDevice cameraDevice:self.cameraDevice];
@@ -448,7 +454,6 @@
         [device unlockForConfiguration];
     }
     
-#if !TARGET_IPHONE_SIMULATOR
     AVCaptureDeviceInput *deviceInput = [AVCaptureDeviceInput deviceInputWithDevice:device error:nil];
     if (!deviceInput) {
         _session = nil;
@@ -470,7 +475,6 @@
     }
     
     [self setCameraFlashMode:_cameraFlashMode];
-#endif
     
     NSDictionary *outputSettings = @{AVVideoCodecKey:AVVideoCodecJPEG};
     
@@ -487,7 +491,8 @@
         [self.videoOutput setSampleBufferDelegate:self queue:self.sampleBufferQueue];
         [_session addOutput:self.videoOutput];
     }
-    
+#endif
+
     if (self.isViewLoaded && self.view.window) {
         [self startRunning];
         [self _insertPreviewLayer];

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -48,7 +48,8 @@
             scalesImage = _scalesImage,
             cameraDevice = _cameraDevice,
             cameraFlashMode = _cameraFlashMode,
-            cameraTorchMode = _cameraTorchMode;
+            cameraTorchMode = _cameraTorchMode,
+            mirrorsOutput = _mirrorsOutput;
 
 - (instancetype)init
 {
@@ -144,6 +145,7 @@
     [self _insertPreviewLayer];
     
     [self _setPreviewVideoOrientation];
+    [self _setPreviewVideoMirroring];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -516,7 +518,7 @@
     }
     
     if ([videoConnection isVideoMirroringSupported]) {
-        [videoConnection setVideoMirrored:(_cameraDevice == FastttCameraDeviceFront)];
+        [videoConnection setVideoMirrored:self.mirrorsOutput];
     }
     
 #if TARGET_IPHONE_SIMULATOR
@@ -643,6 +645,14 @@
     
     if ([videoConnection isVideoOrientationSupported]) {
         [videoConnection setVideoOrientation:[self _currentPreviewVideoOrientationForDevice]];
+    }
+}
+
+- (void)_setPreviewVideoMirroring {
+    AVCaptureConnection *videoConnection = [_previewLayer connection];
+    videoConnection.automaticallyAdjustsVideoMirroring = NO;
+    if ([videoConnection isVideoMirroringSupported]) {
+        [videoConnection setVideoMirrored:self.mirrorsOutput];
     }
 }
 

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -55,6 +55,7 @@
             mirrorsOutput = _mirrorsOutput;
 
 - (instancetype)initWithSendIndividualVideoFrames:(BOOL)sendIndividualVideoFrames {
+    _sampleBufferQueue = dispatch_queue_create("com.xaphod.fastttcamera.samplebuffer", NULL);
     _sendIndividualVideoFrames = sendIndividualVideoFrames;
     return [self init];
 }
@@ -63,7 +64,6 @@
 {
     if ((self = [super init])) {
         
-        _sampleBufferQueue = dispatch_queue_create("com.xaphod.fastttcamera.samplebuffer", NULL);
         [self _setupCaptureSession]; // warning, concurrent/multi-threaded
         
         _handlesTapFocus = YES;

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -510,7 +510,7 @@
     BOOL needsPreviewRotation = ![self.deviceOrientation deviceOrientationMatchesInterfaceOrientation];
     
     AVCaptureConnection *videoConnection = [self _currentCaptureConnection];
-    if (!videoConnection.isActive)
+    if (!videoConnection.isActive || !videoConnection.isEnabled)
         return;
     
     if ([videoConnection isVideoOrientationSupported]) {

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -923,17 +923,13 @@
         CGColorSpaceRelease(colorSpace);
         
         // Create an image object from the Quartz image
-        UIImage *image = [UIImage imageWithCGImage:quartzImage];
-        FastttCapturedImage *capturedImage = [FastttCapturedImage fastttCapturedFullImage: image];
+        NSAssert([connection isVideoOrientationSupported], @"This code assumes up-oriented images");
+        UIImage *image = [UIImage imageWithCGImage:quartzImage scale:1 orientation:(self.mirrorsVideo ? UIImageOrientationUpMirrored : UIImageOrientationUp)];
 
         // Release the Quartz image
         CGImageRelease(quartzImage);
         
-        [capturedImage normalizeWithCallback:^(FastttCapturedImage *capturedImage){
-            if (capturedImage) {
-                [self.delegate cameraController:self didCaptureVideoFrame:capturedImage.fullImage];
-            }
-        }];
+        [self.delegate cameraController:self didCaptureVideoFrame:image];
     }
 }
 

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -51,7 +51,8 @@
             cameraDevice = _cameraDevice,
             cameraFlashMode = _cameraFlashMode,
             cameraTorchMode = _cameraTorchMode,
-            mirrorsOutput = _mirrorsOutput;
+            mirrorsVideo = _mirrorsVideo,
+            mirrorsTakePhoto = _mirrorsTakePhoto;
 
 - (instancetype)init {
     if ((self = [super init])) {
@@ -572,7 +573,7 @@
     }
     
     if ([videoConnection isVideoMirroringSupported]) {
-        [videoConnection setVideoMirrored:self.mirrorsOutput];
+        [videoConnection setVideoMirrored:self.mirrorsTakePhoto];
     }
 
     BOOL needsPreviewRotation = ![self.deviceOrientation deviceOrientationMatchesInterfaceOrientation];
@@ -724,14 +725,14 @@
     AVCaptureConnection *videoConnection = [_previewLayer connection];
     videoConnection.automaticallyAdjustsVideoMirroring = NO;
     if ([videoConnection isVideoMirroringSupported]) {
-        [videoConnection setVideoMirrored:self.mirrorsOutput];
+        [videoConnection setVideoMirrored:self.mirrorsVideo];
     }
 
     if (self.sendIndividualVideoFrames) {
         AVCaptureConnection* connection = self.videoOutput.connections.firstObject;
         connection.automaticallyAdjustsVideoMirroring = NO;
         if ([connection isVideoMirroringSupported]) {
-            [connection setVideoMirrored:self.mirrorsOutput];
+            [connection setVideoMirrored:self.mirrorsVideo];
         }
     }
 }

--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -347,6 +347,8 @@
 
 - (void)startRunning
 {
+    if (!_session)
+        return;
     if (![_session isRunning]) {
         [_session startRunning];
     }
@@ -354,6 +356,8 @@
 
 - (void)stopRunning
 {
+    if (!_session)
+        return;
     if ([_session isRunning]) {
         [_session stopRunning];
     }
@@ -361,7 +365,7 @@
 
 - (void)_insertPreviewLayer
 {
-    if (!_deviceAuthorized) {
+    if (!_deviceAuthorized || !_session) {
         return;
     }
     
@@ -433,6 +437,10 @@
                 
 #if !TARGET_IPHONE_SIMULATOR
                 AVCaptureDeviceInput *deviceInput = [AVCaptureDeviceInput deviceInputWithDevice:device error:nil];
+                if (!deviceInput) {
+                    _session = nil;
+                    return;
+                }
                 [_session addInput:deviceInput];
                 
                 switch (device.position) {

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -297,6 +297,10 @@
 
 @optional
 
+// Added by Tim - called when a frame of the video (via sample buffer) is ready
+// requires sendIndividualVideoFrames = true
+- (void)cameraController:(id<FastttCameraInterface>)cameraController didCaptureVideoFrame:(UIImage*)videoFrame;
+
 /**
  *  Called when the camera controller has obtained the raw data containing the image and metadata.
  *

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -224,9 +224,12 @@
 - (BOOL)isReadyToCapturePhoto;
 
 /**
- *  Triggers the camera to take a photo. Returns false if picture was not taken.
+ *  Triggers the camera to take a photo.
+ *  To use completionBlock, you must set normalizesImageOrientations to YES, otherwise use delegate callbacks
+ *  The completionBlock is optional - you can use it, or the delegate callbacks, or both
+ *  CompletionBlock will be called (potentially immediately) with nil if there's an error
  */
-- (BOOL)takePicture;
+- (void)takePicture:(void(^)(UIImage*))completionBlock;
 
 
 #pragma mark - Process a photo

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -224,9 +224,9 @@
 - (BOOL)isReadyToCapturePhoto;
 
 /**
- *  Triggers the camera to take a photo.
+ *  Triggers the camera to take a photo. Returns false if picture was not taken.
  */
-- (void)takePicture;
+- (BOOL)takePicture;
 
 
 #pragma mark - Process a photo

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -120,6 +120,12 @@
  */
 @property (nonatomic, assign) UIDeviceOrientation fixedInterfaceOrientation;
 
+/**
+ * Whether the output of the camera is mirrored or not. Earlier versions of FastttCamera automatically mirrored if the front camera
+ * was used, here you need to set this property instead.
+ */
+@property (nonatomic, assign) BOOL mirrorsOutput;
+
 #pragma mark - Camera State
 
 /**

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -124,7 +124,8 @@
  * Whether the output of the camera is mirrored or not. Earlier versions of FastttCamera automatically mirrored if the front camera
  * was used, here you need to set this property instead.
  */
-@property (nonatomic, assign) BOOL mirrorsOutput;
+@property (nonatomic, assign) BOOL mirrorsVideo;
+@property (nonatomic, assign) BOOL mirrorsTakePhoto;
 
 #pragma mark - Camera State
 

--- a/FastttCamera/FastttCameraInterface.h
+++ b/FastttCamera/FastttCameraInterface.h
@@ -298,7 +298,7 @@
 @optional
 
 // Added by Tim - called when a frame of the video (via sample buffer) is ready
-// requires sendIndividualVideoFrames = true
+// requires using the init for FasttCamera that specifies sendIndividualVideoFrames as true
 - (void)cameraController:(id<FastttCameraInterface>)cameraController didCaptureVideoFrame:(UIImage*)videoFrame;
 
 /**

--- a/FastttCamera/UIImage+FastttCamera.h
+++ b/FastttCamera/UIImage+FastttCamera.h
@@ -83,7 +83,7 @@
 /**
  *  Scales the image to the given maximum dimension.
  *
- *  @param size The destination maximum dimension of the image.
+ *  @param maxDimension The destination maximum dimension of the image.
  *
  *  @return The scaled image.
  */

--- a/FastttCamera/UIImage+FastttCamera.m
+++ b/FastttCamera/UIImage+FastttCamera.m
@@ -190,12 +190,11 @@ CG_INLINE CGFLOAT_TYPE FastttRound(CGFLOAT_TYPE f) {
                                 FastttRound(self.size.width),
                                 FastttRound(self.size.height));
     
-    CGImageRef imageRef = CGImageRetain(CGImageCreateWithImageInRect([self CGImage], newRect));
-    UIImage *normalized =
-    [UIImage imageWithCGImage:imageRef
-                        scale:[self scale]
-                  orientation: self.imageOrientation];
-    CGImageRelease(imageRef);
+    UIGraphicsBeginImageContextWithOptions(newRect.size, YES, self.scale);
+    [self drawInRect:newRect];
+    
+    UIImage *normalized = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
     
     return normalized;
 }

--- a/FastttCamera/UIImage+FastttCamera.m
+++ b/FastttCamera/UIImage+FastttCamera.m
@@ -190,11 +190,12 @@ CG_INLINE CGFLOAT_TYPE FastttRound(CGFLOAT_TYPE f) {
                                 FastttRound(self.size.width),
                                 FastttRound(self.size.height));
     
-    UIGraphicsBeginImageContextWithOptions(newRect.size, YES, self.scale);
-    [self drawInRect:newRect];
-    
-    UIImage *normalized = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    CGImageRef imageRef = CGImageRetain(CGImageCreateWithImageInRect([self CGImage], newRect));
+    UIImage *normalized =
+    [UIImage imageWithCGImage:imageRef
+                        scale:[self scale]
+                  orientation: self.imageOrientation];
+    CGImageRelease(imageRef);
     
     return normalized;
 }

--- a/FastttCamera/UIViewController+FastttCamera.h
+++ b/FastttCamera/UIViewController+FastttCamera.h
@@ -32,6 +32,12 @@
 - (void)fastttAddChildViewController:(UIViewController *)childViewController belowSubview:(UIView *)siblingSubview;
 
 /**
+ *  Allows specifying which view the subview belongs to, not just self.view
+ *
+ */
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view belowSubview:(UIView *)subview;
+    
+/**
  *  Removes the given child view controller from this view controller and handles
  *  view appearance transition event calls.
  *

--- a/FastttCamera/UIViewController+FastttCamera.h
+++ b/FastttCamera/UIViewController+FastttCamera.h
@@ -35,7 +35,9 @@
  *  Allows specifying which view the subview belongs to, not just self.view
  *
  */
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view;
 - (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view belowSubview:(UIView *)subview;
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view aboveSubview:(UIView *)subview;
     
 /**
  *  Removes the given child view controller from this view controller and handles

--- a/FastttCamera/UIViewController+FastttCamera.m
+++ b/FastttCamera/UIViewController+FastttCamera.m
@@ -27,7 +27,15 @@
     [childViewController didMoveToParentViewController:self];
     [childViewController endAppearanceTransition];
 }
-
+    
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view belowSubview:(UIView *)subview {
+    [childViewController beginAppearanceTransition:YES animated:NO];
+    [self addChildViewController:childViewController];
+    [view insertSubview:childViewController.view belowSubview:subview];
+    [childViewController didMoveToParentViewController:self];
+    [childViewController endAppearanceTransition];
+}
+    
 - (void)fastttRemoveChildViewController:(UIViewController *)childViewController
 {
     [childViewController willMoveToParentViewController:nil];

--- a/FastttCamera/UIViewController+FastttCamera.m
+++ b/FastttCamera/UIViewController+FastttCamera.m
@@ -28,10 +28,26 @@
     [childViewController endAppearanceTransition];
 }
     
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view {
+    [childViewController beginAppearanceTransition:YES animated:NO];
+    [self addChildViewController:childViewController];
+    [view addSubview:childViewController.view];
+    [childViewController didMoveToParentViewController:self];
+    [childViewController endAppearanceTransition];
+}
+    
 - (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view belowSubview:(UIView *)subview {
     [childViewController beginAppearanceTransition:YES animated:NO];
     [self addChildViewController:childViewController];
     [view insertSubview:childViewController.view belowSubview:subview];
+    [childViewController didMoveToParentViewController:self];
+    [childViewController endAppearanceTransition];
+}
+    
+- (void)fastttAddChildViewController:(UIViewController *)childViewController inView:(UIView*)view aboveSubview:(UIView *)subview {
+    [childViewController beginAppearanceTransition:YES animated:NO];
+    [self addChildViewController:childViewController];
+    [view insertSubview:childViewController.view aboveSubview:subview];
     [childViewController didMoveToParentViewController:self];
     [childViewController endAppearanceTransition];
 }


### PR DESCRIPTION
If the deviceOrientation is faceUp or faceDown, then before this change the code assumes this means portrait orientation. This doesn't work for my iPad app, because often a faceUp iPad is in landscape orientation.
This pull request changes the behavior only for faceUp/Down orientation: the statusBar orientation is used instead. This means that faceUp-Landscape and faceUp-Portrait are both supported.