### PR TITLE
Cancel image processing when capturing still image fails

### DIFF
--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -529,6 +529,7 @@
                                                    completionHandler:^(CMSampleBufferRef imageDataSampleBuffer, NSError *error)
      {
          if (!imageDataSampleBuffer) {
+             [self cancelImageProcessing];
              return;
          }
          


### PR DESCRIPTION
Hi!

I'm using FastttCamera to work around [nasty iOS SDK crash](https://openradar.appspot.com/28108858). However I've found a little issue with FastttCamera itself. STR is similar to one from the radar:

1. Present camera with `cameraFlashMode` set to `FastttCameraFlashModeOn`.
2. Take picture.
3. Immediately (before or during the flash), either hit the iPhone's power button to lock it or go to home screen.

In such case taking picture fails and `imageDataSampleBuffer` is empty. Error's description:

```
error Error Domain=AVFoundationErrorDomain Code=-11800 "The operation could not be completed" 
UserInfo={NSUnderlyingError=0x17405ad60 {Error Domain=NSOSStatusErrorDomain Code=-16802 "(null)"},
NSLocalizedFailureReason=An unknown error occurred (-16802), NSLocalizedDescription=The operation could not be completed}
```

On such errors FastttCamera gets stuck in capturing image state. This fix allows to take another picture after a failure.