### PR TITLE
Update FastttCamera.m to silence UI warning 

### DIFF
--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -607,8 +607,10 @@
             [capturedImage scaleToMaxDimension:maxDimension
                                   withCallback:scaleCallback];
         } else if (fromCamera && self.scalesImage) {
-            [capturedImage scaleToSize:self.view.bounds.size
-                          withCallback:scaleCallback];
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                            //Run UI Updates
+                [capturedImage scaleToSize:self.view.bounds.size withCallback:scaleCallback];
+            });
         }
         
         if (fromCamera && !self.isCapturingImage) {


### PR DESCRIPTION
This update fixes the `-[UIView bounds] must be used from main thread only` warning 