### PR TITLE
Avoid freezing issues by removing session operations during the app lifecycle.

### DIFF
--- a/FastttCamera/FastttCamera.m
+++ b/FastttCamera/FastttCamera.m
@@ -161,26 +161,22 @@
 
 - (void)applicationWillEnterForeground:(NSNotification *)notification
 {
-    [self _setupCaptureSession];
+    // No need to perform any actions here; frequent session operations can increase the risk of camera freezing.
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
-    if (self.isViewLoaded && self.view.window) {
-        [self startRunning];
-        [self _insertPreviewLayer];
-        [self _setPreviewVideoOrientation];
-    }
+    // No need to perform any actions here; frequent session operations can increase the risk of camera freezing.
 }
 
 - (void)applicationWillResignActive:(NSNotification *)notification
 {
-    [self stopRunning];
+    // No need to perform any actions here; frequent session operations can increase the risk of camera freezing.
 }
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification
 {
-    [self _teardownCaptureSession];
+    // No need to perform any actions here; frequent session operations can increase the risk of camera freezing.
 }
 
 #pragma mark - Autorotation


### PR DESCRIPTION
I used FastttCamera in my app and collected some freezing stack traces by Apple’s MetricKit:

```
0   libsystem_kernel.dylib        	0x00000001b72ad4e0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	0x00000001b72adb24 mach_msg + 76 (mach_msg.c:119)
2   CoreFoundation                	0x0000000180408820 __CFRunLoopServiceMachPort + 372 (CFRunLoop.c:2646)
3   CoreFoundation                	0x000000018040ccac __CFRunLoopRun + 1180 (CFRunLoop.c:3000)
4   CoreFoundation                	0x00000001804206b8 CFRunLoopRunSpecific + 600 (CFRunLoop.c:3268)
5   AVFCore                       	0x0000000189a5d60c -[AVRunLoopCondition _waitInMode:untilDate:] + 412 (AVRunLoopCondition.m:174)
6   AVFCapture                    	0x000000019f46125c -[AVCaptureSession _stopFigCaptureSession] + 436 (AVCaptureSession.m:2031)
7   AVFCapture                    	0x000000019f444284 -[AVCaptureSession _setRunning:] + 180 (AVCaptureSession.m:2103)
```

After reviewing Apple's documentation, I noticed that in the [camera demo provided by Apple](https://developer.apple.com/documentation/avfoundation/capture_setup/avcam_building_a_camera_app?language=objc), the session operations (such as session init, start running, stop running) are not triggered during app lifecycle changes, and everything functions normally. So I removed this part of the code from my app, and the freezing issues disappeared. Therefore, I believe that frequent session operations can overburden the camera, leading to freezing problems.